### PR TITLE
Avoid Ctrl-Shift-C which conflicts

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -26,7 +26,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "Ctrl+Shift+C",
+        "default": "Alt+Shift+C",
         "mac": "MacCtrl+Shift+C"
       },
       "description": "Opens popup.html"


### PR DESCRIPTION
* Ctrl-Shift-C is a default keyboard shortcut for chrome developer tool "Toggle Inspect Element Mode"
    * https://developers.google.com/web/tools/chrome-devtools/shortcuts